### PR TITLE
decode as utf 8

### DIFF
--- a/json_transport/src/json_transport/json_transport.py
+++ b/json_transport/src/json_transport/json_transport.py
@@ -40,7 +40,7 @@ class PackedJson(rospy.msg.AnyMsg):
         self._buff = msgpack.packb(data)
 
     def get_data(self):
-        return msgpack.unpackb(self._buff)
+        return msgpack.unpackb(self._buff, encoding="utf-8")
 
     data = property(get_data, set_data)
 


### PR DESCRIPTION
This allows json_transport to work in Python3.  

Without explicitly defining the encoding, it decodes as bytes, which Python3 distinguishes from string, unlike Python2.