### PR TITLE
Provide helpers for nested fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,19 @@ auto received = ros::topic::waitForMessage<json_transport::json_t>("json");
 assert(*received == sent);
 ```
 
+Nested `json_msg/Json` types can be packed/unpacked via helper methods:
+
+```
+MyCustomMessage message();
+message.json_field = json_transport::pack(json_data)
+
+assert(json_data == json_transport::unpack(message.json_field))
+```
+
+
 ## Python
 
-The provided `json_transport.PackedJson` message type allows publishing and subscribing anything that can be serialized/deserialized natively via the stdlib `json` module.
+The provided `json_transport.PackedJson` data type allows publishing and subscribing anything that can be serialized/deserialized natively via the stdlib `json` module.
 
 ```
 import json_transport
@@ -49,4 +59,14 @@ pub.publish({'a': 1, 'b': 2, 'c': 3})
 msg = rospy.wait_for_message('json', json_transport.PackedJson)
 
 assert msg.data == {'a': 1, 'b': 2, 'c': 3}
+```
+
+Nested `json_msg/Json` types can be packed/unpacked via helper methods:
+
+```
+msg = MyCustomMessage(
+    json_field=json_transport.pack(serializable_data)
+)
+
+assert serializable_data == json_transport.unpack(msg.json_field)
 ```

--- a/json_transport/include/json_transport/json_transport.hpp
+++ b/json_transport/include/json_transport/json_transport.hpp
@@ -35,6 +35,18 @@ namespace json_transport
 {
   typedef nlohmann::json json_t;
   typedef json_msgs::Json json_msg_t;
+
+  inline json_t unpack(json_msg_t message)
+  {
+    return json_t::from_msgpack(message.bytes);
+  }
+
+  inline json_msg_t pack(json_t data)
+  {
+    json_msg_t message{};
+    message.bytes = json_t::to_msgpack(data);
+    return message;
+  }
 }
 
 namespace ros
@@ -96,27 +108,34 @@ struct Serializer<json_transport::json_t>
   template<typename Stream>
   inline static void write(Stream& stream, const json_transport::json_t& json)
   {
-    std::vector<std::uint8_t> bytes = json_transport::json_t::to_msgpack(json);
-    for (auto const & byte : bytes)
-    {
-      stream.next(byte);
-    }
+    json_transport::json_msg_t message = json_transport::pack(json);
+    Serializer<json_transport::json_msg_t>::write(stream, message);
+
+    // std::vector<std::uint8_t> bytes = json_transport::json_t::to_msgpack(json);
+    // for (auto const & byte : bytes)
+    // {
+    //   stream.next(byte);
+    // }
   }
 
   template<typename Stream>
   inline static void read(Stream& stream, json_transport::json_t& json)
   {
-    std::vector<std::uint8_t> bytes(stream.getLength());
-    for (auto & byte : bytes)
-    {
-      stream.next(byte);
-    }
-    json = json_transport::json_t::from_msgpack(bytes);
+    json_transport::json_msg_t message;
+    Serializer<json_transport::json_msg_t>::read(stream, message);
+    json = json_transport::unpack(message);
+
+    // std::vector<std::uint8_t> bytes(stream.getLength());
+    // for (auto & byte : bytes)
+    // {
+    //   stream.next(byte);
+    // }
+    // json = json_transport::json_t::from_msgpack(bytes);
   }
 
   inline static uint32_t serializedLength(const json_transport::json_t& json)
   {
-    return json_transport::json_t::to_msgpack(json).size();
+    return json_transport::json_t::to_msgpack(json).size() + 4;
   }
 };
 

--- a/json_transport/include/json_transport/json_transport.hpp
+++ b/json_transport/include/json_transport/json_transport.hpp
@@ -110,12 +110,6 @@ struct Serializer<json_transport::json_t>
   {
     json_transport::json_msg_t message = json_transport::pack(json);
     Serializer<json_transport::json_msg_t>::write(stream, message);
-
-    // std::vector<std::uint8_t> bytes = json_transport::json_t::to_msgpack(json);
-    // for (auto const & byte : bytes)
-    // {
-    //   stream.next(byte);
-    // }
   }
 
   template<typename Stream>
@@ -124,13 +118,6 @@ struct Serializer<json_transport::json_t>
     json_transport::json_msg_t message;
     Serializer<json_transport::json_msg_t>::read(stream, message);
     json = json_transport::unpack(message);
-
-    // std::vector<std::uint8_t> bytes(stream.getLength());
-    // for (auto & byte : bytes)
-    // {
-    //   stream.next(byte);
-    // }
-    // json = json_transport::json_t::from_msgpack(bytes);
   }
 
   inline static uint32_t serializedLength(const json_transport::json_t& json)

--- a/json_transport/src/json_transport/json_transport.py
+++ b/json_transport/src/json_transport/json_transport.py
@@ -28,19 +28,24 @@ import rospy
 from json_msgs import msg as json_msg
 
 
-class PackedJson(rospy.msg.AnyMsg):
+def pack(data):
+    return json_msg.Json(bytes=msgpack.packb(data))
 
-    _md5sum = json_msg.Json._md5sum
-    _type = json_msg.Json._type
+
+def unpack(message):
+    return msgpack.unpackb(message.bytes, encoding="utf-8")
+
+
+class PackedJson(json_msg.Json):
 
     def __init__(self, data=None):
         self.data = data
 
     def set_data(self, data):
-        self._buff = msgpack.packb(data)
+        self.bytes = msgpack.packb(data)
 
     def get_data(self):
-        return msgpack.unpackb(self._buff, encoding="utf-8")
+        return msgpack.unpackb(self.bytes, encoding="utf-8")
 
     data = property(get_data, set_data)
 


### PR DESCRIPTION
Slightly more indirect approach to serialization, but required to support having a nested json field in a message.