### PR TITLE
Pull in jsonschema via requirements.txt

### DIFF
--- a/json_transport/CMakeLists.txt
+++ b/json_transport/CMakeLists.txt
@@ -17,8 +17,15 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 
+install(FILES requirements.txt
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
 if(CATKIN_ENABLE_TESTING)
+  find_package(catkin_virtualenv)
   find_package(roslint)
+
+  catkin_generate_virtualenv()
+
   roslint_cpp()
   roslint_python()
 

--- a/json_transport/package.xml
+++ b/json_transport/package.xml
@@ -41,10 +41,13 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <depend>json_msgs</depend>
   <depend>roscpp</depend>
 
-  <exec_depend>python-jsonschema</exec_depend>
-
+  <test_depend>catkin_virtualenv</test_depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>rosunit</test_depend>
+
+  <export>
+    <pip_requirements>requirements.txt</pip_requirements>
+  </export>
 
 </package>

--- a/json_transport/requirements.txt
+++ b/json_transport/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema==3.2.0


### PR DESCRIPTION
A system dependency won't cut it for the multiple possible downstream python versions.